### PR TITLE
FIX: remove amount rounding

### DIFF
--- a/lib/helperModels.js
+++ b/lib/helperModels.js
@@ -46,7 +46,7 @@ class BankAmount {
    * Parses amount, identifies sign based on Debit or Credit mark.
    * @param {string} dcmark - D or C = Debit or credit (C = positive), prefix 'R' -> change of sign, reversed
    * @param {string} amoutStr - string with positive float number
-   * @return {float} amount, rounded to 2 fractional digits, with sign
+   * @return {float} amount, not rounded, with sign
    * @static
    */
   // eslint-disable-next-line complexity
@@ -67,7 +67,7 @@ class BankAmount {
 
     if (dc === 'D') {amount = amount.multipliedBy(-1);} // Bank debit = minus
     if (eOrR === 'R') {amount = amount.multipliedBy(-1);}
-    return amount.multipliedBy(100).integerValue().dividedBy(100);
+    return amount;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "swiftmessageparser",
-      "version": "1.0.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "bignumber.js": "^9.0.1",

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -52,8 +52,8 @@ describe('Helpers', () => {
         expect(helpers.Amount.parse('C', '123,34')).toEqual(BigNumber(123.34));
       });
 
-      it('should round to 2 fractional digits', () => {
-        expect(helpers.Amount.parse('C', '123,345')).toEqual(BigNumber(123.35));
+      it('should not round any fractional digits', () => {
+        expect(helpers.Amount.parse('C', '123,3456789')).toEqual(BigNumber(123.3456789));
       });
 
       it('should fail if wrong indicator passed', () => {


### PR DESCRIPTION
According to [ISO_4217](https://en.wikipedia.org/wiki/ISO_4217) there are currencies that use from 0 to 4 number of digits after the decimal separator.
We should not round any amounts sent and parse as is.